### PR TITLE
Update IMEI and chipname adb commands

### DIFF
--- a/android_triage.sh
+++ b/android_triage.sh
@@ -154,6 +154,9 @@ info_collect () {
         NAME=$($SHELL_COMMAND getprop ro.product.name)
         PRODUCT_CODE=$($SHELL_COMMAND getprop ro.product.code)
         CHIPNAME=$($SHELL_COMMAND getprop ro.chipname)
+        if [[ -z ${CHIPNAME} ]]; then
+	       CHIPNAME=$($SHELL_COMMAND getprop ro.hardware ro.hardware.chipname)
+        fi
         SERIAL_NUMBER=$($SHELL_COMMAND getprop ril.serialnumber)
         BASEBAND_VERSION=$($SHELL_COMMAND getprop gsm.version.baseband)
         COUNTRY_CODE=$($SHELL_COMMAND getprop ro.csc.country_code)
@@ -175,6 +178,9 @@ info_collect () {
         IMEI=$(${ADB} shell dumpsys iphonesubinfo | grep 'Device ID' | grep -o '[0-9]+')
         if [[ -z ${IMEI} ]]; then
 	       IMEI=$(${ADB} shell service call iphonesubinfo 1 | awk -F "'" '{print $2}' | sed '1 d' | tr -d '.' | awk '{print}' ORS=)
+        fi
+        if [[ -z ${IMEI} ]]; then
+	       IMEI=$(${ADB} shell service call iphonesubinfo 1 s16 com.android.shell  | cut -d "'" -f2| grep -Eo '[0-9]'| xargs| sed 's/\ //g')
         fi
 
         if [[ $(adb shell id) =~ "root" ]] || [[ $(adb shell su -c id) =~ "root" ]];then 


### PR DESCRIPTION
Previous commands seemed to not work anymore. I added some new ones coming from these websites : 
- https://xdaforums.com/t/s22-imei-via-adb-not-working.4428173/
- https://stackoverflow.com/questions/51726539/get-chip-name-of-the-android-device-using-adb

IMEI and chipname now works on Samsung S8, S20 and Google Pixel 7a.

Also, after doing some searches, i think that the "Android Serial number" and "Device Serial Number" are the same identifiers. The command `adb shell getprop ril.serialnumber` does not output anything on my phones.